### PR TITLE
feat: add GitHub Actions workflow for running pytest in Maya 2026

### DIFF
--- a/.github/workflows/test-mayapy.yml
+++ b/.github/workflows/test-mayapy.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository_owner }}/maya-brew:latest
+      options: --user root
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
@@ -27,7 +28,7 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.repository_owner }}" --password-stdin
 
       - name: Install requirements
-        run: mayapy -m pip install --pre .[dev]
+        run: mayapy -m pip install .[dev]
 
       - name: Run pytest
         shell: bash

--- a/.github/workflows/test-mayapy.yml
+++ b/.github/workflows/test-mayapy.yml
@@ -14,8 +14,8 @@ permissions:
 jobs:
   mayapy-tests:
     runs-on: ubuntu-latest
-    env:
-      IMAGE: ghcr.io/${{ github.repository_owner }}/maya-brew:latest
+    container:
+      image: ghcr.io/${{ github.repository_owner }}/maya-brew:latest
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8

--- a/.github/workflows/test-mayapy.yml
+++ b/.github/workflows/test-mayapy.yml
@@ -23,15 +23,11 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 1
-
       - name: Install requirements
         run: mayapy -m pip install .[dev]
-
       - name: Run pytest
         shell: bash
         run: mayapy -m pytest tests/
-
       - name: Summary
         if: success()
         run: echo "mayapy pytest run succeeded." >> "$GITHUB_STEP_SUMMARY"
-

--- a/.github/workflows/test-mayapy.yml
+++ b/.github/workflows/test-mayapy.yml
@@ -24,9 +24,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Login to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.repository_owner }}" --password-stdin
-
       - name: Install requirements
         run: mayapy -m pip install .[dev]
 

--- a/.github/workflows/test-mayapy.yml
+++ b/.github/workflows/test-mayapy.yml
@@ -1,0 +1,38 @@
+name: Pytest Maya 2026
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - develop
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  mayapy-tests:
+    runs-on: ubuntu-latest
+    env:
+      IMAGE: ghcr.io/${{ github.repository_owner }}/maya-brew:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+        with:
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Login to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.repository_owner }}" --password-stdin
+
+      - name: Install requirements
+        run: mayapy -m pip install --pre .[dev]
+
+      - name: Run pytest
+        shell: bash
+        run: mayapy -m pytest tests/
+
+      - name: Summary
+        if: success()
+        run: echo "mayapy pytest run succeeded." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test-mayapy.yml
+++ b/.github/workflows/test-mayapy.yml
@@ -15,7 +15,7 @@ jobs:
   mayapy-tests:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/${{ github.repository_owner }}/maya-brew:latest
+      image: ghcr.io/${{ github.repository_owner }}/maya-brew:sha-9daa1a4
       options: --user root
     steps:
       - name: Checkout
@@ -34,3 +34,4 @@ jobs:
       - name: Summary
         if: success()
         run: echo "mayapy pytest run succeeded." >> "$GITHUB_STEP_SUMMARY"
+


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate testing for Maya 2026 using `mayapy` and `pytest`. The workflow is designed to run on key events such as pushes to the `develop` branch, pull requests, and manual triggers. It ensures that the test suite is executed in a consistent environment using a pre-built Docker image.