### PR TITLE
19 list attributes on a node

### DIFF
--- a/src/maya_brew/attributes/node_attribute.py
+++ b/src/maya_brew/attributes/node_attribute.py
@@ -157,6 +157,9 @@ class Attribute:
 class FloatAttribute(Attribute):
     _getter_type = "asDouble"
 
+class BoolAttribute(Attribute):
+    _getter_type = "asBool"
+
 
 class MessageAttribute(Attribute):
     _getter_type = "kMessage"
@@ -173,4 +176,5 @@ class MessageAttribute(Attribute):
 _API_TYPE_SUBCLASS_MAP = {
     "kDoubleLinearAttribute": FloatAttribute,
     "kMessageAttribute": MessageAttribute,
+    "kNumericAttribute": BoolAttribute
 }

--- a/src/maya_brew/attributes/node_attribute.py
+++ b/src/maya_brew/attributes/node_attribute.py
@@ -184,15 +184,18 @@ class TypedAttribute(Attribute):
     """
     _getter_type = "asMObject"
 
+
+class CompoundAttribute(Attribute):
+    """
+    Handles Maya kCompoundAttribute types. Returns a list of child Attribute instances.
+    """
     @classmethod
     def _get_plug_value(cls, plug: OpenMaya2.MPlug):
-        try:
-            # Try to extract as MObject (generic typed data)
-            return plug.asMObject()
-        except Exception as e:
-            raise MayaBrewAttributeError(
-                f"Failed to extract value from kTypedAttribute plug '{plug.name()}'."
-            ) from e
+        children = []
+        for i in range(plug.numChildren()):
+            child_plug = plug.child(i)
+            children.append(Attribute(child_plug))
+        return children
 
 
 _API_TYPE_SUBCLASS_MAP = {
@@ -201,6 +204,7 @@ _API_TYPE_SUBCLASS_MAP = {
     "kNumericAttribute": BoolAttribute,
     "kEnumAttribute": EnumAttribute,
     "kTypedAttribute": TypedAttribute,
+    "kCompoundAttribute": CompoundAttribute,
 }
 
 

--- a/src/maya_brew/attributes/node_attribute.py
+++ b/src/maya_brew/attributes/node_attribute.py
@@ -206,6 +206,29 @@ class CompoundAttribute(Attribute):
             children.append(Attribute(child_plug))
         return children
 
+class MultiFloatAttribute(Attribute):
+    _num_children: int
+
+    @classmethod
+    def _get_plug_value(cls, plug: OpenMaya2.MPlug):
+        if plug.numChildren() != cls._num_children:
+            raise MayaBrewAttributeError(f"Expected {cls._num_children} children for kAttribute3Double, got {plug.numChildren()} on '{plug.name()}'")
+        return tuple(plug.child(i).asDouble() for i in range(cls._num_children))
+
+class Float2Attribute(Attribute):
+    """
+    Handles Maya kAttribute2Double types (e.g., UV coordinates).
+    Returns a tuple of two float values (u, v).
+    """
+    _num_children = 2
+
+class Float3Attribute(Attribute):
+    """
+    Handles Maya kAttribute3Double types (e.g., translate, rotate, scale).
+    Returns a tuple of three float values (x, y, z).
+    """
+    _num_children = 3
+
 
 _API_TYPE_SUBCLASS_MAP = {
     "kDoubleLinearAttribute": FloatAttribute,
@@ -214,6 +237,10 @@ _API_TYPE_SUBCLASS_MAP = {
     "kEnumAttribute": EnumAttribute,
     "kTypedAttribute": TypedAttribute,
     "kCompoundAttribute": CompoundAttribute,
+    "kAttribute3Double": Float3Attribute,
+    "kAttribute2Float": Float2Attribute,
+    "kAttribute3Float": Float3Attribute,
+    "kDoubleAngleAttribute": FloatAttribute,
 }
 
 

--- a/src/maya_brew/attributes/node_attribute.py
+++ b/src/maya_brew/attributes/node_attribute.py
@@ -1,6 +1,7 @@
 import typing
 
 from .. import OpenMaya2, cmds
+from ..exceptions import MayaBrewAttributeError
 from ..nodes import cast
 from ..nodes.node_types import DagNode, Node
 
@@ -39,7 +40,7 @@ class Attribute:
             subclass: type[Attribute] = _API_TYPE_SUBCLASS_MAP[api_type]
         except KeyError:
             raise NotImplementedError(
-                f"Unsupported attribute apiTypeStr '{api_type}'. "
+                f"Unsupported attribute apiTypeStr '{api_type}'. Could cast attribute for '{plug}'. "
                 f"Known types: {sorted(_API_TYPE_SUBCLASS_MAP)}"
             )
 
@@ -103,7 +104,7 @@ class Attribute:
         return self._get_node_from_plug(self.plug)
 
     def name(self):
-        raise NotImplementedError
+        return self.plug.name()
 
     def connect(self, dest: "Attribute", force: bool = False, next_available=False):
         """
@@ -166,11 +167,11 @@ class MessageAttribute(Attribute):
 
     @classmethod
     def _get_plug_value(cls, plug: OpenMaya2.MPlug):
-        raise AttributeError("Message attributes do not hold data.")
+        raise MayaBrewAttributeError("Message attributes do not hold data.")
 
     @classmethod
     def set(cls, value):
-        raise AttributeError("Message attributes are not settable.")
+        raise MayaBrewAttributeError("Message attributes are not settable.")
 
 
 _API_TYPE_SUBCLASS_MAP = {
@@ -178,3 +179,16 @@ _API_TYPE_SUBCLASS_MAP = {
     "kMessageAttribute": MessageAttribute,
     "kNumericAttribute": BoolAttribute
 }
+
+
+class AttributeAccessor:
+    def __init__(self, node: "Node"):
+        self._node = node
+
+    def __getattr__(self, attr_name: str):
+        try:
+            return Attribute(f"{self._node}.{attr_name}")
+        except (ValueError, RuntimeError, NotImplementedError, AttributeError) as e:
+            raise MayaBrewAttributeError(
+                f"Failed to access attribute '{attr_name}' on node '{self._node}'"
+            ) from e

--- a/src/maya_brew/attributes/node_attribute.py
+++ b/src/maya_brew/attributes/node_attribute.py
@@ -2,7 +2,6 @@ import typing
 
 from .. import OpenMaya2, cmds
 from ..exceptions import MayaBrewAttributeError
-from ..nodes import cast
 from ..nodes.node_types import DagNode, Node
 
 PlugInput = typing.Union[OpenMaya2.MPlug, str]
@@ -81,7 +80,9 @@ class Attribute:
         :return: The MPlug for the attribute.
         """
         if "." not in path:
-            raise ValueError("Attribute path must include a '.' separating node and attribute.")
+            raise ValueError(
+                "Attribute path must include a '.' separating node and attribute."
+            )
         node_path, attr_name = path.rsplit(".", 1)
         selection_list = OpenMaya2.MSelectionList()
         selection_list.add(node_path)
@@ -167,6 +168,7 @@ class Attribute:
 class FloatAttribute(Attribute):
     _getter_type = "asDouble"
 
+
 class BoolAttribute(Attribute):
     _getter_type = "asBool"
 
@@ -182,6 +184,7 @@ class MessageAttribute(Attribute):
     def set(cls, value):
         raise MayaBrewAttributeError("Message attributes are not settable.")
 
+
 class EnumAttribute(Attribute):
     _getter_type = "asShort"
 
@@ -191,6 +194,7 @@ class TypedAttribute(Attribute):
     Handles Maya kTypedAttribute types. By default, returns the MObject stored in the plug.
     Extend this class if you need to handle specific typed data (e.g., strings, matrices).
     """
+
     _getter_type = "asMObject"
 
 
@@ -198,6 +202,7 @@ class CompoundAttribute(Attribute):
     """
     Handles Maya kCompoundAttribute types. Returns a list of child Attribute instances.
     """
+
     @classmethod
     def _get_plug_value(cls, plug: OpenMaya2.MPlug):
         children = []
@@ -206,34 +211,43 @@ class CompoundAttribute(Attribute):
             children.append(Attribute(child_plug))
         return children
 
+
 class MultiFloatAttribute(Attribute):
     _num_children: int
 
     @classmethod
     def _get_plug_value(cls, plug: OpenMaya2.MPlug):
         if plug.numChildren() != cls._num_children:
-            raise MayaBrewAttributeError(f"Expected {cls._num_children} children for kAttribute3Double, got {plug.numChildren()} on '{plug.name()}'")
+            raise MayaBrewAttributeError(
+                f"Expected {cls._num_children} children for kAttribute3Double, got {plug.numChildren()} on '{plug.name()}'"
+            )
         return tuple(plug.child(i).asDouble() for i in range(cls._num_children))
+
 
 class Float2Attribute(Attribute):
     """
     Handles Maya kAttribute2Double types (e.g., UV coordinates).
     Returns a tuple of two float values (u, v).
     """
+
     _num_children = 2
+
 
 class Float3Attribute(Attribute):
     """
     Handles Maya kAttribute3Double types (e.g., translate, rotate, scale).
     Returns a tuple of three float values (x, y, z).
     """
+
     _num_children = 3
+
 
 class Float4Attribute(Attribute):
     """
     Handles Maya kAttribute4Double types (e.g., quaternions).
     Returns a tuple of four float values (x, y, z, w).
     """
+
     _num_children = 4
 
 
@@ -241,6 +255,7 @@ class MatrixAttribute(Attribute):
     """
     Handles Maya kMatrixAttribute types. Returns an OpenMaya2.MMatrix instance.
     """
+
     @classmethod
     def _get_plug_value(cls, plug: OpenMaya2.MPlug):
         mobj = plug.asMObject()
@@ -252,9 +267,11 @@ class GenericAttribute(Attribute):
     """
     Handles Maya kGenericAttribute types. Returns the MObject stored in the plug, or raises an error if not supported.
     """
+
     @classmethod
     def _get_plug_value(cls, plug: OpenMaya2.MPlug):
         return plug.asMObject()
+
 
 _API_TYPE_SUBCLASS_MAP = {
     "kDoubleLinearAttribute": FloatAttribute,

--- a/src/maya_brew/attributes/node_attribute.py
+++ b/src/maya_brew/attributes/node_attribute.py
@@ -230,6 +230,17 @@ class Float3Attribute(Attribute):
     _num_children = 3
 
 
+class MatrixAttribute(Attribute):
+    """
+    Handles Maya kMatrixAttribute types. Returns an OpenMaya2.MMatrix instance.
+    """
+    @classmethod
+    def _get_plug_value(cls, plug: OpenMaya2.MPlug):
+        mobj = plug.asMObject()
+        matrix_data = OpenMaya2.MFnMatrixData(mobj)
+        return matrix_data.matrix()
+
+
 _API_TYPE_SUBCLASS_MAP = {
     "kDoubleLinearAttribute": FloatAttribute,
     "kMessageAttribute": MessageAttribute,
@@ -241,6 +252,7 @@ _API_TYPE_SUBCLASS_MAP = {
     "kAttribute2Float": Float2Attribute,
     "kAttribute3Float": Float3Attribute,
     "kDoubleAngleAttribute": FloatAttribute,
+    "kMatrixAttribute": MatrixAttribute,
 }
 
 

--- a/src/maya_brew/attributes/node_attribute.py
+++ b/src/maya_brew/attributes/node_attribute.py
@@ -75,20 +75,19 @@ class Attribute:
     @staticmethod
     def _plug_from_path(path: str) -> OpenMaya2.MPlug:
         """
-        Resolve a string path to an MPlug.
+        Resolve a string path to an MPlug using MSelectionList and MFnDependencyNode.
+        Works for both DAG and dependency nodes without casting.
         :param path: The full path to the attribute, e.g. '|grp|node|nodeShape.visibility'
         :return: The MPlug for the attribute.
         """
-        # Split path into node path and attribute name
         if "." not in path:
-            raise ValueError(
-                "Attribute path must include a '.' separating node and attribute."
-            )
+            raise ValueError("Attribute path must include a '.' separating node and attribute.")
         node_path, attr_name = path.rsplit(".", 1)
-        node_dag_path = cast.get_dag_path_from_string(node_path)
-        node = DagNode(node_dag_path.fullPathName())
-        plug = Attribute._get_plug_from_node(node, attr_name)
-        return plug
+        selection_list = OpenMaya2.MSelectionList()
+        selection_list.add(node_path)
+        mobj = selection_list.getDependNode(0)
+        fn_dep = OpenMaya2.MFnDependencyNode(mobj)
+        return fn_dep.findPlug(attr_name, False)
 
     def __str__(self):
         return self.name()
@@ -132,13 +131,23 @@ class Attribute:
         )
 
     @classmethod
-    def _get_value(cls, node: DagNode, attr_name: str):
+    def _get_value(cls, node: Node, attr_name: str):
         plug = cls._get_plug_from_node(node, attr_name)
         return cls._get_plug_value(plug)
 
     @staticmethod
-    def _get_plug_from_node(node: DagNode, attr_name: str) -> OpenMaya2.MPlug:
-        fn_dep = node.get_mfndependency_node()
+    def _get_plug_from_node(node: Node, attr_name: str) -> OpenMaya2.MPlug:
+        """
+        Get the MPlug for the given attribute name from a Node or DagNode.
+        """
+        if hasattr(node, "get_mfndependency_node"):
+            fn_dep = node.get_mfndependency_node()
+        else:
+            # For non-DAG nodes, resolve node.node_path to MObject
+            selection_list = OpenMaya2.MSelectionList()
+            selection_list.add(node.node_path)
+            mobj = selection_list.getDependNode(0)
+            fn_dep = OpenMaya2.MFnDependencyNode(mobj)
         return fn_dep.findPlug(attr_name, False)
 
     @staticmethod

--- a/src/maya_brew/attributes/node_attribute.py
+++ b/src/maya_brew/attributes/node_attribute.py
@@ -229,6 +229,13 @@ class Float3Attribute(Attribute):
     """
     _num_children = 3
 
+class Float4Attribute(Attribute):
+    """
+    Handles Maya kAttribute4Double types (e.g., quaternions).
+    Returns a tuple of four float values (x, y, z, w).
+    """
+    _num_children = 4
+
 
 class MatrixAttribute(Attribute):
     """
@@ -241,6 +248,14 @@ class MatrixAttribute(Attribute):
         return matrix_data.matrix()
 
 
+class GenericAttribute(Attribute):
+    """
+    Handles Maya kGenericAttribute types. Returns the MObject stored in the plug, or raises an error if not supported.
+    """
+    @classmethod
+    def _get_plug_value(cls, plug: OpenMaya2.MPlug):
+        return plug.asMObject()
+
 _API_TYPE_SUBCLASS_MAP = {
     "kDoubleLinearAttribute": FloatAttribute,
     "kMessageAttribute": MessageAttribute,
@@ -249,10 +264,12 @@ _API_TYPE_SUBCLASS_MAP = {
     "kTypedAttribute": TypedAttribute,
     "kCompoundAttribute": CompoundAttribute,
     "kAttribute3Double": Float3Attribute,
+    "kAttribute4Double": Float4Attribute,
     "kAttribute2Float": Float2Attribute,
     "kAttribute3Float": Float3Attribute,
     "kDoubleAngleAttribute": FloatAttribute,
     "kMatrixAttribute": MatrixAttribute,
+    "kGenericAttribute": GenericAttribute,
 }
 
 

--- a/src/maya_brew/attributes/node_attribute.py
+++ b/src/maya_brew/attributes/node_attribute.py
@@ -173,11 +173,34 @@ class MessageAttribute(Attribute):
     def set(cls, value):
         raise MayaBrewAttributeError("Message attributes are not settable.")
 
+class EnumAttribute(Attribute):
+    _getter_type = "asShort"
+
+
+class TypedAttribute(Attribute):
+    """
+    Handles Maya kTypedAttribute types. By default, returns the MObject stored in the plug.
+    Extend this class if you need to handle specific typed data (e.g., strings, matrices).
+    """
+    _getter_type = "asMObject"
+
+    @classmethod
+    def _get_plug_value(cls, plug: OpenMaya2.MPlug):
+        try:
+            # Try to extract as MObject (generic typed data)
+            return plug.asMObject()
+        except Exception as e:
+            raise MayaBrewAttributeError(
+                f"Failed to extract value from kTypedAttribute plug '{plug.name()}'."
+            ) from e
+
 
 _API_TYPE_SUBCLASS_MAP = {
     "kDoubleLinearAttribute": FloatAttribute,
     "kMessageAttribute": MessageAttribute,
-    "kNumericAttribute": BoolAttribute
+    "kNumericAttribute": BoolAttribute,
+    "kEnumAttribute": EnumAttribute,
+    "kTypedAttribute": TypedAttribute,
 }
 
 

--- a/src/maya_brew/exceptions.py
+++ b/src/maya_brew/exceptions.py
@@ -3,6 +3,7 @@ class MayaBrewException(Exception):
 
     pass
 
+
 class MayaBrewAttributeError(MayaBrewException, AttributeError):
     """Raised when there is an attribute-related error in MayaBrew."""
 

--- a/src/maya_brew/exceptions.py
+++ b/src/maya_brew/exceptions.py
@@ -2,3 +2,8 @@ class MayaBrewException(Exception):
     """Base class for all MayaBrew exceptions."""
 
     pass
+
+class MayaBrewAttributeError(MayaBrewException, AttributeError):
+    """Raised when there is an attribute-related error in MayaBrew."""
+
+    pass

--- a/src/maya_brew/nodes/node_types.py
+++ b/src/maya_brew/nodes/node_types.py
@@ -1,8 +1,10 @@
-from typing import Any, Callable, Dict, Self
+from typing import Any, Callable, Dict, Self, TYPE_CHECKING
 
 from .. import OpenMaya2, cmds
 from ..log import get_logger
 from ..nodes import cast
+if TYPE_CHECKING:
+    from ..attributes.node_attribute import Attribute
 
 logger = get_logger(__name__)
 logger.setLevel("DEBUG")
@@ -47,6 +49,15 @@ class Node:
         if cmds_value != name:
             logger.debug(f"Name was not unique. New name: {cmds_value}.")
         return cls(cmds_value)
+
+    def list_attributes(self, **kwargs) -> list["Attribute"]:
+        """
+        List all attributes of the current node.
+        :return: A list of all attributes of the current node.
+        """
+        from maya_brew.attributes.node_attribute import Attribute
+        return [Attribute(f"{self}.{cmds_attr}") for cmds_attr in cmds.listAttr(str(self), **kwargs)] or []
+
 
 
 class DagNode(Node):

--- a/src/maya_brew/nodes/node_types.py
+++ b/src/maya_brew/nodes/node_types.py
@@ -3,8 +3,9 @@ from typing import Any, Callable, Dict, Self, TYPE_CHECKING
 from .. import OpenMaya2, cmds
 from ..log import get_logger
 from ..nodes import cast
+
 if TYPE_CHECKING:
-    from ..attributes.node_attribute import Attribute
+    from ..attributes.node_attribute import Attribute, AttributeAccessor
 
 logger = get_logger(__name__)
 logger.setLevel("DEBUG")
@@ -58,6 +59,10 @@ class Node:
         from maya_brew.attributes.node_attribute import Attribute
         return [Attribute(f"{self}.{cmds_attr}") for cmds_attr in cmds.listAttr(str(self), **kwargs)] or []
 
+    @property
+    def at(self) -> "AttributeAccessor":
+        from ..attributes.node_attribute import AttributeAccessor
+        return AttributeAccessor(self)
 
 
 class DagNode(Node):

--- a/src/maya_brew/nodes/node_types.py
+++ b/src/maya_brew/nodes/node_types.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Self, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Dict, Self
 
 from .. import OpenMaya2, cmds
 from ..log import get_logger
@@ -57,11 +57,16 @@ class Node:
         :return: A list of all attributes of the current node.
         """
         from maya_brew.attributes.node_attribute import Attribute
-        return [Attribute(f"{self}.{cmds_attr}") for cmds_attr in cmds.listAttr(str(self), **kwargs)] or []
+
+        return [
+            Attribute(f"{self}.{cmds_attr}")
+            for cmds_attr in cmds.listAttr(str(self), **kwargs)
+        ] or []
 
     @property
     def at(self) -> "AttributeAccessor":
         from ..attributes.node_attribute import AttributeAccessor
+
         return AttributeAccessor(self)
 
 

--- a/tests/maya_brew/nodes/test_node_types.py
+++ b/tests/maya_brew/nodes/test_node_types.py
@@ -2,6 +2,7 @@ import logging
 
 import maya_brew.nodes.cast
 import maya_brew.nodes.node_types
+from maya_brew.attributes.node_attribute import Attribute
 
 
 def test_dag_node_string(test_cube, caplog):
@@ -40,3 +41,7 @@ def test_Transform_repr():
     assert name in repr
     assert dag_node.get_full_path() in repr
     assert type(dag_node).__name__ in repr
+
+def test_list_attributes(brew_transform):
+    for a in brew_transform.list_attributes():
+        assert isinstance(a, Attribute)

--- a/tests/maya_brew/nodes/test_node_types.py
+++ b/tests/maya_brew/nodes/test_node_types.py
@@ -1,8 +1,10 @@
 import logging
 
+import pytest
 import maya_brew.nodes.cast
 import maya_brew.nodes.node_types
 from maya_brew.attributes.node_attribute import Attribute
+from maya_brew.exceptions import MayaBrewAttributeError
 
 
 def test_dag_node_string(test_cube, caplog):
@@ -42,6 +44,41 @@ def test_Transform_repr():
     assert dag_node.get_full_path() in repr
     assert type(dag_node).__name__ in repr
 
+
 def test_list_attributes(brew_transform):
     for a in brew_transform.list_attributes():
         assert isinstance(a, Attribute)
+
+
+def test_node_at_returns_attribute(brew_transform):
+    attr = brew_transform.at.visibility
+    from maya_brew.attributes.node_attribute import Attribute
+    assert isinstance(attr, Attribute)
+    assert 'visibility' in str(attr)
+    assert brew_transform.node_path in str(attr)
+
+
+def test_node_at_invalid_attribute_raises(brew_transform):
+    with pytest.raises(MayaBrewAttributeError):
+        _ = brew_transform.at.non_existent_attr
+
+
+def test_node_at_on_dagnode(test_cube):
+    from maya_brew.nodes.node_types import DagNode
+    dag_node = DagNode(test_cube)
+    attr = dag_node.at.visibility
+    from maya_brew.attributes.node_attribute import Attribute
+    assert isinstance(attr, Attribute)
+    assert 'visibility' in str(attr)
+    assert dag_node.node_path in str(attr)
+
+
+def test_node_at_on_transform():
+    from maya_brew.nodes.node_types import Transform
+    name = "test_transform"
+    transform = Transform.create(name)
+    attr = transform.at.visibility
+    from maya_brew.attributes.node_attribute import Attribute
+    assert isinstance(attr, Attribute)
+    assert 'visibility' in str(attr)
+    assert transform.node_path in str(attr)

--- a/tests/maya_brew/nodes/test_node_types.py
+++ b/tests/maya_brew/nodes/test_node_types.py
@@ -1,8 +1,8 @@
 import logging
 
-import pytest
 import maya_brew.nodes.cast
 import maya_brew.nodes.node_types
+import pytest
 from maya_brew.attributes.node_attribute import Attribute
 from maya_brew.exceptions import MayaBrewAttributeError
 
@@ -53,8 +53,9 @@ def test_list_attributes(brew_transform):
 def test_node_at_returns_attribute(brew_transform):
     attr = brew_transform.at.visibility
     from maya_brew.attributes.node_attribute import Attribute
+
     assert isinstance(attr, Attribute)
-    assert 'visibility' in str(attr)
+    assert "visibility" in str(attr)
     assert brew_transform.node_path in str(attr)
 
 
@@ -65,20 +66,24 @@ def test_node_at_invalid_attribute_raises(brew_transform):
 
 def test_node_at_on_dagnode(test_cube):
     from maya_brew.nodes.node_types import DagNode
+
     dag_node = DagNode(test_cube)
     attr = dag_node.at.visibility
     from maya_brew.attributes.node_attribute import Attribute
+
     assert isinstance(attr, Attribute)
-    assert 'visibility' in str(attr)
+    assert "visibility" in str(attr)
     assert dag_node.node_path in str(attr)
 
 
 def test_node_at_on_transform():
     from maya_brew.nodes.node_types import Transform
+
     name = "test_transform"
     transform = Transform.create(name)
     attr = transform.at.visibility
     from maya_brew.attributes.node_attribute import Attribute
+
     assert isinstance(attr, Attribute)
-    assert 'visibility' in str(attr)
+    assert "visibility" in str(attr)
     assert transform.node_path in str(attr)


### PR DESCRIPTION
# Pull Request

## What does this PR do?

Implement functionality to list attributes on nodes, attribute lookup on nodes.
This also significantly enhances attribute handling for Maya nodes by introducing new attribute types, improving error handling, and adding convenient accessors. The main changes include support for more Maya attribute types,

* Added multiple new attribute subclasses (`BoolAttribute`, `EnumAttribute`, `TypedAttribute`, `CompoundAttribute`, `Float2Attribute`, `Float3Attribute`, `Float4Attribute`, `MatrixAttribute`, `GenericAttribute`, `MultiFloatAttribute`) to support a wider range of Maya attribute types.
* Improved the `_plug_from_path` and `_get_plug_from_node` methods to robustly resolve both DAG and dependency nodes, allowing attribute access without explicit casting
* Added `list_attributes` method to `Node` for enumerating all attributes, and the `at` property returning an `AttributeAccessor` for convenient attribute access via dot notation (e.g., `node.at.visibility`)


## Related Issue

Link to issue (if any):

mortenbohne/maya-brew#19

## Testing

* Added comprehensive tests for the new attribute access patterns, error handling, and attribute listing to ensure reliability and correct behavior.

## Checklist

- [x] I reviewed my code
- [x] My change does not break existing features

## Extra notes

(Optional)
