### PR TITLE
16 getting and setting of all standard attribute types

### DIFF
--- a/src/maya_brew/attributes/node_attribute.py
+++ b/src/maya_brew/attributes/node_attribute.py
@@ -122,6 +122,22 @@ class Attribute:
     def name(self):
         return self.plug.name()
 
+    def api_type(self, as_string: bool = True):
+        """
+        Return the underlying OpenMaya API type for this attribute's MObject.
+        :param as_string: If True, return apiTypeStr (e.g. 'kTypedAttribute'),
+                          else return apiType() integer enum.
+        """
+        mobj_attr = self.plug.attribute()
+        if as_string:
+            api_type_str = getattr(mobj_attr, "apiTypeStr", None)
+            if not api_type_str:
+                raise MayaBrewAttributeError(
+                    f"Unable to resolve apiTypeStr for attribute '{self.plug.name()}'."
+                )
+            return api_type_str
+        return mobj_attr.apiType()
+
     def connect(self, dest: "Attribute", force: bool = False, next_available=False):
         """
         Connect this attribute to another attribute.
@@ -547,6 +563,29 @@ class CompoundAttribute(_AttributeWithCreatedChildren):
     """
 
     _creator_type = "compound"
+
+    @classmethod
+    def _get_plug_value(cls, plug: OpenMaya2.MPlug):
+        if not plug.isCompound:
+            raise MayaBrewAttributeError(
+                f"Attribute '{plug.name()}' is not a compound plug."
+            )
+
+        children: list[Attribute] = []
+        for i in range(plug.numChildren()):
+            try:
+                child_plug = plug.child(i)
+            except RuntimeError:
+                # Some Maya internal compound attrs do not expose child plugs.
+                continue
+            children.append(Attribute(child_plug))
+
+        if not children:
+            raise MayaBrewAttributeError(
+                f"Compound attribute '{plug.name()}' has no accessible child plugs."
+            )
+
+        return children
 
 
 class MultiFloatAttribute(_AttributeWithCreatedChildren):

--- a/src/maya_brew/attributes/node_attribute.py
+++ b/src/maya_brew/attributes/node_attribute.py
@@ -104,7 +104,12 @@ class Attribute:
         return self.name()
 
     def get(self):
-        return self._get_plug_value(self.plug)
+        try:
+            return self._get_plug_value(self.plug)
+        except RuntimeError as e:
+            raise MayaBrewAttributeError(
+                f"Failed to get value for attribute '{self.plug.name()}': {e}"
+            ) from e
 
     def set(self, value):
         attr_name = self.plug.name()

--- a/src/maya_brew/attributes/node_attribute.py
+++ b/src/maya_brew/attributes/node_attribute.py
@@ -143,6 +143,12 @@ class Attribute:
             return api_type_str
         return mobj_attr.apiType()
 
+    def is_readable(self) -> bool:
+        """
+        Returns True if the attribute is readable, False otherwise.
+        """
+        return OpenMaya2.MFnAttribute(self.plug.attribute()).readable
+
     def connect(self, dest: "Attribute", force: bool = False, next_available=False):
         """
         Connect this attribute to another attribute.

--- a/src/maya_brew/nodes/node_types.py
+++ b/src/maya_brew/nodes/node_types.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Callable, Dict, Self
+from typing import TYPE_CHECKING, Any, Callable, Dict, Self, overload, TypeVar
 
 from .. import OpenMaya2, cmds
 from ..log import get_logger
@@ -6,6 +6,8 @@ from ..nodes import cast
 
 if TYPE_CHECKING:
     from ..attributes.node_attribute import Attribute, AttributeAccessor
+
+A = TypeVar("A", bound="Attribute")
 
 logger = get_logger(__name__)
 logger.setLevel("DEBUG")
@@ -51,17 +53,32 @@ class Node:
             logger.debug(f"Name was not unique. New name: {cmds_value}.")
         return cls(cmds_value)
 
-    def list_attributes(self, **kwargs) -> list["Attribute"]:
+    @overload
+    def list_attributes(self, attr_type: type[A], **kwargs) -> list[A]: ...
+
+    @overload
+    def list_attributes(
+        self, attr_type: None = None, **kwargs
+    ) -> list["Attribute"]: ...
+
+    def list_attributes(
+        self, attr_type: "type[A] | None" = None, **kwargs
+    ) -> "list[A] | list[Attribute]":
         """
-        List all attributes of the current node.
-        :return: A list of all attributes of the current node.
+        List attributes on this node.
+        :param attr_type: If provided, only return attributes of this maya-brew type.
         """
         from maya_brew.attributes.node_attribute import Attribute
 
-        return [
+        attrs = [
             Attribute(f"{self}.{cmds_attr}")
             for cmds_attr in cmds.listAttr(str(self), **kwargs)
-        ] or []
+        ]
+
+        if attr_type is not None:
+            return [a for a in attrs if isinstance(a, attr_type)]
+
+        return attrs
 
     @property
     def at(self) -> "AttributeAccessor":

--- a/tests/maya_brew/attributes/test_node_attributes.py
+++ b/tests/maya_brew/attributes/test_node_attributes.py
@@ -185,3 +185,22 @@ def test_attribute_creation(brew_transform):
         assert not cmds.attributeQuery(
             attr_name, node=brew_transform.node_path, exists=True
         )
+
+
+def test_is_readable(brew_transform):
+    tx = Attribute(f"{brew_transform.node_path}.translateX")
+    assert tx.is_readable() is True
+
+    created_attr = FloatAttribute.create(
+        node_name=brew_transform.node_path,
+        attr_name="my_readable_float",
+        readable=True,
+    )
+    assert created_attr.is_readable() is True
+
+    created_attr_non_readable = FloatAttribute.create(
+        node_name=brew_transform.node_path,
+        attr_name="my_non_readable_float",
+        readable=False,
+    )
+    assert created_attr_non_readable.is_readable() is False

--- a/tests/maya_brew/nodes/test_node_types.py
+++ b/tests/maya_brew/nodes/test_node_types.py
@@ -92,9 +92,9 @@ def test_node_at_on_transform():
 def test_list_attributes_type_filter(brew_transform):
     from maya_brew.attributes.node_attribute import FloatAttribute, BoolAttribute
 
-    float_attrs = brew_transform.list_attributes(of_type=FloatAttribute)
+    float_attrs = brew_transform.list_attributes(attr_type=FloatAttribute)
     assert all(isinstance(a, FloatAttribute) for a in float_attrs)
     assert len(float_attrs) > 0
 
-    bool_attrs = brew_transform.list_attributes(of_type=BoolAttribute)
+    bool_attrs = brew_transform.list_attributes(attr_type=BoolAttribute)
     assert all(isinstance(a, BoolAttribute) for a in bool_attrs)

--- a/tests/maya_brew/nodes/test_node_types.py
+++ b/tests/maya_brew/nodes/test_node_types.py
@@ -87,3 +87,14 @@ def test_node_at_on_transform():
     assert isinstance(attr, Attribute)
     assert "visibility" in str(attr)
     assert transform.node_path in str(attr)
+
+
+def test_list_attributes_type_filter(brew_transform):
+    from maya_brew.attributes.node_attribute import FloatAttribute, BoolAttribute
+
+    float_attrs = brew_transform.list_attributes(of_type=FloatAttribute)
+    assert all(isinstance(a, FloatAttribute) for a in float_attrs)
+    assert len(float_attrs) > 0
+
+    bool_attrs = brew_transform.list_attributes(of_type=BoolAttribute)
+    assert all(isinstance(a, BoolAttribute) for a in bool_attrs)


### PR DESCRIPTION
# Pull Request

## What does this PR do?

better error-handling for getting attributes

functionality for getting attribute's api_type

functionality to check if attribute is readable

node.list_attributes can now filter based on maya brew attribute types, and hint correct return type


## Related Issue

Link to issue (if any):

mortenbohne/maya-brew#16

## Testing

How did you test your changes? (Leave blank if not needed)


## Checklist

- [x] I reviewed my code
- [x] My change does not break existing features

## Extra notes

(Optional)
